### PR TITLE
use prometheus instead of gxed

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-0.3.9: QmbqQP7GMwJCePfEvbMSZmyPifAz1kKZifo8vwVnVHt1wL
+0.3.10: QmQXBfkuwgMaPx334WuL9NmyrKnbZ5udaWnHTHEsts2x3T

--- a/binding.go
+++ b/binding.go
@@ -3,9 +3,9 @@ package metricsprometheus
 import (
 	"strings"
 
-	pro "github.com/gxed/client_golang/prometheus"
 	logging "github.com/ipfs/go-log"
 	metrics "github.com/ipfs/go-metrics-interface"
+	pro "github.com/prometheus/client_golang/prometheus"
 )
 
 var log logging.EventLogger = logging.Logger("metrics-prometheus")

--- a/package.json
+++ b/package.json
@@ -31,6 +31,6 @@
   "license": "MIT",
   "name": "go-metrics-prometheus",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "0.3.9"
+  "version": "0.3.10"
 }
 

--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
   "gxDependencies": [
     {
       "author": "whyrusleeping",
-      "hash": "QmYYv3QFnfQbiwmi1tpkgKF8o4xFnZoBrvpupTiGJwL9nH",
+      "hash": "QmTQuFQWHAWy4wMH6ZyPfGiawA5u9T8rs79FENoV8yXaoS",
       "name": "client_golang",
-      "version": "0.1.3"
+      "version": "0.1.4"
     },
     {
       "author": "ipfs",


### PR DESCRIPTION
Users should build with gx anyways. If they don't, we might as well give them
upstream.